### PR TITLE
Look for existing entries to prevent duplicates

### DIFF
--- a/src/notion.js
+++ b/src/notion.js
@@ -12,6 +12,24 @@ const {
 
 const logLevel = CI ? LogLevel.INFO : LogLevel.DEBUG;
 
+export async function getExistingPages(items) {
+  const notion = new Client({
+    auth: NOTION_API_TOKEN,
+    logLevel,
+  });
+  const response = await notion.databases.query({
+    database_id: NOTION_READER_DATABASE_ID,
+    or: items.map((item) => ({
+      property: 'Link',
+      text: {
+        equals: item.link,
+      },
+    })),
+  });
+
+  return response.results;
+}
+
 export async function getFeedUrlsFromNotion() {
   const notion = new Client({
     auth: NOTION_API_TOKEN,


### PR DESCRIPTION
I was able to do it with only one api call to get all pages from the reader database which have matching links to the currently pulled feed items. Then before adding notion pages we just check if the feed item exists in that list.